### PR TITLE
fix🛠️(calllog): Исправить значение по умолчанию для get_data_from_hours

### DIFF
--- a/src/calllogdb/calllog.py
+++ b/src/calllogdb/calllog.py
@@ -118,7 +118,7 @@ class CallLog:
         logger.debug("Параметры запроса для дня: {}", asdict(params))
         self.__requests(params)
 
-    def get_data_from_hours(self, hour: int = -1) -> None:
+    def get_data_from_hours(self, hour: int = 1) -> None:
         logger.info("Получение данных за последние {} часов", hour)
         params = RequestParams(
             date_from=DateParams().adjust_date(-hour, "hour"),


### PR DESCRIPTION
🛠️ Ранее метод get_data_from_hours использовал -1 в качестве значения по умолчанию, что могло приводить к некорректному вычислению временного интервала. Теперь значение по умолчанию установлено в 1, что соответствует ожидаемому поведению.